### PR TITLE
Set pasv_promiscuous to 'NO'

### DIFF
--- a/templates/vsftpd.conf.template
+++ b/templates/vsftpd.conf.template
@@ -32,6 +32,4 @@ port_promiscuous=NO
 pasv_min_port=0
 pasv_max_port=0
 listen_port=5757
-pasv_promiscuous=YES
-port_promiscuous=YES
 seccomp_sandbox=no


### PR DESCRIPTION
+ this option enables the PASV security check that ensures the data connection originates from the same IP address as the control connection. You can set this to yes if you need possible FXP support... however, please note, this is supported via vsftpd - not QuickBox