### PR TITLE
Fix upgradeBTSync

### DIFF
--- a/templates/bashrc.template
+++ b/templates/bashrc.template
@@ -1576,8 +1576,8 @@ echo ${OK}
 }
 
 function upgradeBTSync() {
-  apt-get install -yqq -f --only-upgrade btsync
-  service btsync restart
+  apt-get install -yqq -f --only-upgrade resilio-sync
+  service resilio-sync restart
 }
 
 function upgradePlex() {


### PR DESCRIPTION
The service is now "resilio-sync"

BTSync is a recognized name, but it's formally been renamed resilio-sync. Maybe we should update this command (upgradeResilio-sync)? The user may not recognize it though.